### PR TITLE
Allow passing multiple URL's to the `Video()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Laravel Youtube Library
+# Laravel Youtube Library
 This library is used for fetching videos and channels from youtube using a URL.
 
 ### Dependencies
@@ -6,15 +6,25 @@ This library is used for fetching videos and channels from youtube using a URL.
 * [vinelab/http](https://github.com/Vinelab/http)
 
 ### Installation
-* Clone the repository from [here](https://bitbucket.org/adibhanna/youtube).
-* Edit app.php and add ```Najem\Videos\VideosServiceProvider```
-* the ```Youtube``` Facade can be used to access the package's functionalities.
-
+1. Include using Composer: `"vinelab/youtube" : "*"`
+2. Add the service provider
+`'Vinelab\Youtube\YoutubeServiceProvider'`
+3. Add the Facade `'Youtube'         => 'Vinelab\Youtube\Facades\Youtube'`
+4. Publish the config file `php artisan config:publish Vinelab/youtube`
+5. Add your key to the config file
+ 
 ### Usage
-* To fetch a video by id use ```Youtube::video($url)```
-this will return an object of type ```Najem\Videos\Video```
+Use the `Youtube` Facade to access the package's functionalities.
+___
 
-#### Response
+#### `Youtube::video($url)`
+
+>> To fetch a video use `Youtube::video($url)`
+this will return an object of type `Najem\Videos\Video`
+
+Note: you can fetch multiple `videos` at once by passing an `array` of `Url's`, to `Youtube::videos($urls)` or even `Youtube::video($urls)`.
+
+##### Response:
 
 ```json
 object(Vinelab\Youtube\Video)[180]
@@ -38,11 +48,14 @@ object(Vinelab\Youtube\Video)[180]
       'standard' => string 'https://i1.ytimg.com/vi/1j1MBSwg44A/sddefault.jpg' (length=49)
       'maxres' => string 'https://i1.ytimg.com/vi/1j1MBSwg44A/maxresdefault.jpg' (length=53)
 ```
+___
 
-* To fetch a Channel by name or by id use ```Youtube::channel($url)```
-this will return an object of type ```Najem\Videos\Channel```
+#### `Youtube::channel($url)`
 
-#### Response
+>> To fetch a Channel use `Youtube::channel($url)`
+this will return an object of type `Najem\Videos\Channel`
+
+##### Response:
 
 ```json
 object(Najem\Videos\Channel)[209]

--- a/src/Vinelab/Youtube/Contracts/ApiInterface.php
+++ b/src/Vinelab/Youtube/Contracts/ApiInterface.php
@@ -11,9 +11,11 @@ interface ApiInterface {
     public function get($url, $params);
 
     /**
-     * Get single video info
-     * @param  string                       $video_id
-     * @return Vinelab\Youtube\YoutubeVideo
+     * Get videos info
+     *
+     * @param  string|array   $video_ids
+     *
+     * @return stdClass
      */
     public function video($video_id);
 

--- a/src/Vinelab/Youtube/Contracts/ManagerInterface.php
+++ b/src/Vinelab/Youtube/Contracts/ManagerInterface.php
@@ -5,11 +5,11 @@ use Vinelab\Youtube\ResourceInterface;
 interface ManagerInterface {
 
     /**
-     * Return a video info
-     * @param  string                $vid
-     * @return Vinelab\Youtube\Video
+     * Return a videos info
+     * @param string|array $urls
+     * @return \Vinelab\Youtube\Contracts\Vinelab\Youtube\YoutubeVideo
      */
-    public function video($vid);
+    public function videos($vid);
 
     /**
      * return the channel's videos by id or by username.

--- a/src/Vinelab/Youtube/Manager.php
+++ b/src/Vinelab/Youtube/Manager.php
@@ -3,9 +3,11 @@
 use Vinelab\Youtube\Contracts\ApiInterface;
 use Vinelab\Youtube\Contracts\ManagerInterface;
 use Vinelab\Youtube\Contracts\SynchronizerInterface;
+use Vinelab\Youtube\Contracts\Vinelab;
 use Vinelab\Youtube\Helpers\YoutubeUrlParser as UrlParser;
 
-class Manager implements ManagerInterface {
+class Manager implements ManagerInterface
+{
 
     /**
      * The api instance.
@@ -21,33 +23,44 @@ class Manager implements ManagerInterface {
 
     /**
      * Create a new Manager instance
+     *
      * @param ApiInterface          $youtube
      * @param SynchronizerInterface $synchronizer
      */
-    public function __construct(ApiInterface $api,
-                                SynchronizerInterface $synchronizer)
-    {
+    public function __construct(
+        ApiInterface $api,
+        SynchronizerInterface $synchronizer
+    ) {
         $this->api = $api;
         $this->synchronizer = $synchronizer;
     }
 
     /**
-     * Return a video info
-     * @param  string                $url
-     * @return Vinelab\Youtube\Video
+     * Return a videos info
+     *
+     * @param string|array $urls
+     *
+     * @return \Vinelab\Youtube\Contracts\Vinelab\Youtube\YoutubeVideo
      */
-    public function video($url)
+    public function videos($urls)
     {
-        //parser the url and return the video id
-        $vid = UrlParser::parseId($url);
+        if (! is_array($urls)) {
+            return $this->api->video(UrlParser::parseId($urls));
+        }
+        // if array parse each url
+        $vids = array_map(function ($url) {
+            return UrlParser::parseId($url);
+        }, $urls);
 
-        return $this->api->video($vid);
+        return $this->api->video($vids);
     }
 
     /**
      * return the channel's videos by id or by username.
-     * @param  string                  $id_or_name
-     * @param  date                    $synced_at
+     *
+     * @param  string $id_or_name
+     * @param  date   $synced_at
+     *
      * @return Vinelab\Youtube\Channel
      */
     public function videosForChannel($url, $synced_at = null)
@@ -60,7 +73,9 @@ class Manager implements ManagerInterface {
 
     /**
      * Sync a resource (channel or video)
+     *
      * @param  ResourceInterface $resource
+     *
      * @return Channel|Video
      */
     public function sync(ResourceInterface $resource)
@@ -74,7 +89,9 @@ class Manager implements ManagerInterface {
 
     /**
      * return the type of object
+     *
      * @param  Object $object
+     *
      * @return string
      */
     protected function typeOf($object)
@@ -92,11 +109,23 @@ class Manager implements ManagerInterface {
     public function prepareUrl($url)
     {
         if (!preg_match('/http[s]?:\/\//', $url, $matches)) {
-            $url = 'http://'.$url;
+            $url = 'http://' . $url;
 
             return $url;
         }
 
         return $url;
+    }
+
+    /**
+     * Return a video info
+     *
+     * @param  string $vid
+     *
+     * @return Vinelab\Youtube\Video
+     */
+    public function video($vid)
+    {
+        // TODO: Implement video() method.
     }
 }

--- a/src/Vinelab/Youtube/Validators/ExpectedYoutubeResponse.php
+++ b/src/Vinelab/Youtube/Validators/ExpectedYoutubeResponse.php
@@ -16,7 +16,8 @@ class ExpectedYoutubeResponse {
                     'totalResults'      =>  'example',
                     'resultsPerPage'    =>  'example',
                 ],
-                'items' =>  [[
+                'items' =>  [
+                    [
                     'kind'  =>  'example',
                     'etag'  =>  'example',
                     'id'    =>  'example',
@@ -56,7 +57,8 @@ class ExpectedYoutubeResponse {
                         'categoryId'    =>  'example',
                         'liveBroadcastContent'  =>  'example',
                     ],
-                ]],
+                ]
+                ],
             ];
     }
 

--- a/src/Vinelab/Youtube/Validators/Validator.php
+++ b/src/Vinelab/Youtube/Validators/Validator.php
@@ -43,9 +43,10 @@ abstract class Validator implements Contracts\ValidatorInterface {
      */
     protected function expectedKeys($attributes, $expected)
     {
-        $result = $this->intersect($attributes, $expected);
+        // TODO: remove this commented out function !
+//        $result = $this->intersect($attributes, $expected);
 
-        return ($result === $attributes) ? true : false;
+        return (array_keys($attributes) === array_keys($expected)) ? true : false;
     }
 
     /**

--- a/src/Vinelab/Youtube/Validators/VideoResponseValidator.php
+++ b/src/Vinelab/Youtube/Validators/VideoResponseValidator.php
@@ -19,6 +19,7 @@ class VideoResponseValidator extends Validator {
          * as the expected response from youtube.
          * if not, throw InvalidResponseException.
          */
+
         if (! $this->expectedKeys($attributes, ExpectedYoutubeResponse::video())) {
             throw new InvalidResponseException();
         }

--- a/src/Vinelab/Youtube/Youtube.php
+++ b/src/Vinelab/Youtube/Youtube.php
@@ -1,9 +1,10 @@
 <?php namespace Vinelab\Youtube;
 
-use Vinelab\Youtube\Contracts\YoutubeInterface;
 use Vinelab\Youtube\Contracts\ManagerInterface;
+use Vinelab\Youtube\Contracts\YoutubeInterface;
 
-class Youtube implements YoutubeInterface {
+class Youtube implements YoutubeInterface
+{
 
     /**
      * The manager instance
@@ -13,6 +14,7 @@ class Youtube implements YoutubeInterface {
 
     /**
      * Create a new instance of Youtube
+     *
      * @param ManagerInterface $manager
      */
     public function __construct(ManagerInterface $manager)
@@ -21,19 +23,35 @@ class Youtube implements YoutubeInterface {
     }
 
     /**
+     * return a videos info
+     *
+     * @param  array $urls
+     *
+     * @return Vinelab\Youtube\Video
+     */
+    public function videos($urls)
+    {
+        return $this->manager->videos($urls);
+    }
+
+    /**
      * return a single video info
-     * @param  string                $url
+     *
+     * @param  string $url
+     *
      * @return Vinelab\Youtube\Video
      */
     public function video($url)
     {
-        return $this->manager->video($url);
+        return $this->videos($url);
     }
 
     /**
      * return a channel with its videos
-     * @param  string                  $url
-     * @param  date                    $synced_at
+     *
+     * @param  string $url
+     * @param  date   $synced_at
+     *
      * @return Vinelab\Youtube\Channel
      */
     public function channel($url, $synced_at = null)
@@ -43,7 +61,9 @@ class Youtube implements YoutubeInterface {
 
     /**
      * sync the resource
+     *
      * @param  Video|Channel $resource
+     *
      * @return Video|Channel
      */
     public function sync(ResourceInterface $resource)

--- a/tests/Vinelab/Youtube/ChannelTest.php
+++ b/tests/Vinelab/Youtube/ChannelTest.php
@@ -3,6 +3,7 @@
 use Mockery as M;
 use Vinelab\Youtube\Channel;
 use Vinelab\Youtube\VideoCollection;
+use Vinelab\Youtube\tests\TestCase;
 
 class ChannelTest extends TestCase {
 

--- a/tests/Vinelab/Youtube/ParserTest.php
+++ b/tests/Vinelab/Youtube/ParserTest.php
@@ -5,6 +5,7 @@ use Vinelab\Youtube\Video;
 use Vinelab\Youtube\Parser;
 use Vinelab\Youtube\Contracts\VideoInterface;
 use Vinelab\Youtube\Contracts\ChannelInterface;
+use Vinelab\Youtube\tests\TestCase;
 
 class ParserTest extends TestCase {
 

--- a/tests/Vinelab/Youtube/SynchronizerTest.php
+++ b/tests/Vinelab/Youtube/SynchronizerTest.php
@@ -9,6 +9,7 @@ use Vinelab\Youtube\Synchronizer;
 use Vinelab\Youtube\VideoCollection;
 use Vinelab\Youtube\Contracts\VideoInterface;
 use Vinelab\Youtube\Contracts\ChannelInterface;
+use Vinelab\Youtube\tests\TestCase;
 
 class SynchronizerTest extends TestCase {
 

--- a/tests/Vinelab/Youtube/YoutubeTest.php
+++ b/tests/Vinelab/Youtube/YoutubeTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as M;
 use Vinelab\Youtube\Youtube;
+use Vinelab\Youtube\tests\TestCase;
 
 class YoutubeTest extends TestCase {
 


### PR DESCRIPTION
You can now fetch multiple videos at once by passing an array of Url's, to `Youtube::videos($urls)` or even `Youtube::video($urls)`.
The previous function `Youtube::video($urls)` still works as expected when receiving a single URL.